### PR TITLE
Pass all needed whitespace to parser.

### DIFF
--- a/test/putStream_spec.js
+++ b/test/putStream_spec.js
@@ -21,7 +21,7 @@ describe("n3.putStream", function() {
   it("should store some triples", function(done) {
     var stream = db.n3.putStream()
     tj.split("\n").forEach(function(line) {
-      stream.write(line)
+      stream.write(line + "\n")
     })
     stream.end()
     stream.on('finish', function() {


### PR DESCRIPTION
Newlines got stripped off, resulting in an incorrect Turtle document and thus (correctly) a parser error.
