### PR TITLE
Properly check for .n3 file extensions in import.js

### DIFF
--- a/import.js
+++ b/import.js
@@ -62,8 +62,8 @@ try {
     var n3file = path.resolve(filepath);
 
     // must be .nt or .n3 file
-    if (path.extname(n3file) !== '.nt' && path.extname(n3file) !== 'n3') {
-      console.log('Invalid file. Must be .nt or n3 file.');
+    if (path.extname(n3file) !== '.nt' && path.extname(n3file) !== '.n3') {
+      console.log('Invalid file. Must be .nt or .n3 file.');
     } else {
     
       if (!options.quiet) console.log('\nImporting RDF N-triple file: ' + n3file);


### PR DESCRIPTION
This PR addresses an issue where you cannot load .n3 files using import.js.